### PR TITLE
パスワードチェックをAdministratorService内で行うよう修正

### DIFF
--- a/src/main/java/com/example/repository/AdministratorRepository.java
+++ b/src/main/java/com/example/repository/AdministratorRepository.java
@@ -94,10 +94,7 @@ public class AdministratorRepository {
 			return null;
 		}
 
-		// 入力されたパスワードがデータベースに保存されているパスワードと一致しない場合、nullを返します。
-		if (!(isPasswordMatch(password, administratorList.get(0).getPassword()))) {
-			return null;
-		}
+
 
 		// メールアドレスとパスワードが一致する管理者を返します。
 		return administratorList.get(0);

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -37,7 +37,12 @@ public class AdministratorService {
 	 * @return 管理者情報 存在しない場合はnullが返ります
 	 */
 	public Administrator login(String mailAddress, String password) {
-		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
+		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
+		// 入力されたパスワードがデータベースに保存されているパスワードと一致しない場合、nullを返します。
+		if (!(administratorRepository.isPasswordMatch(password, administrator.getPassword()))) {
+			return null;
+		}
+
 		return administrator;
 	}
 


### PR DESCRIPTION
AdministratorRepository　findByMailAddressAndPasswardメソッドで行っていたパスワードチェックをAdministratorServiceのログインメソッドで行うように修正しました。findByMailAddressAndPasswardを使う必要がなくなったのでRepository内のfindByMailAddressメソッドを使っています。